### PR TITLE
Strip 'image/webp,' from the 'Accept' header before requesting from the image source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ node_modules
 tmp/camouflage.pid
 tmp/camo.pid
 .node-version
+.idea/.rakeTasks
+.idea/camo.iml
+.idea/misc.xml
+.idea/modules.xml
+.idea/workspace.xml

--- a/server.coffee
+++ b/server.coffee
@@ -227,6 +227,7 @@ server = Http.createServer (req, resp) ->
     # through the proxy.  So the only option we have left is to use the image proxy to strip out the
     # 'image/webp,' from the 'Accept' header so we stop using webp through the image proxy altogether.
     # Some relevant links:
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values
     # https://support.cloudflare.com/hc/en-us/articles/217343117-What-headers-can-I-vary-the-cache-on-
     # http://stackoverflow.com/questions/37629854/impossible-to-serve-webp-images-using-cloudflare
     # https://xenforo.com/community/threads/getting-proxy-images-to-work-well-with-cloudflare-compression-polish.105817/

--- a/server.coffee
+++ b/server.coffee
@@ -218,8 +218,8 @@ server = Http.createServer (req, resp) ->
     # QUANTOPIAN CHANGED: We added the if block below to strip out 'image/webp,' from
     # the transferred 'Accept' header.  Only Chrome can handle webp currently, so if Cloudflare
     # caches  the webp version of an image, which happens if Chrome is the first type of browser
-    # to request a particular image, that image appears broken for non-Chrome browsers.  Ideally
-    # Cloudflare would just store a copy of the image for each content type, but unfortunately
+    # to request a particular gravatar image, that image appears broken for non-Chrome browsers.
+    # Ideally Cloudflare would just store a copy of the image for each content type, but unfortunately
     # it only supports varying the cache based on the 'Accept-Encoding' header (and we would
     # need it to vary the cache based on the 'Accept' header or the content type of the file).
     # It initially seemed like Cloudflare's new image compression offering Polish would do the right thing for

--- a/server.coffee
+++ b/server.coffee
@@ -215,10 +215,30 @@ server = Http.createServer (req, resp) ->
     url = Url.parse req.url
     user_agent = process.env.CAMO_HEADER_VIA or= "Camo Asset Proxy #{version}"
 
+    # QUANTOPIAN CHANGED: We added the if block below to strip out 'image/webp,' from
+    # the transferred 'Accept' header.  Only Chrome can handle webp currently, so if Cloudflare
+    # caches  the webp version of an image, which happens if Chrome is the first type of browser
+    # to request a particular image, that image appears broken for non-Chrome browsers.  Ideally
+    # Cloudflare would just store a copy of the image for each content type, but unfortunately
+    # it only supports varying the cache based on the 'Accept-Encoding' header (and we would
+    # need it to vary the cache based on the 'Accept' header or the content type of the file).
+    # It initially seemed like Cloudflare's new image compression offering Polish would do the right thing for
+    # us, but it requires our images to have extensions on them, which they don't when being served
+    # through the proxy.  So the only option we have left is to use the image proxy to strip out the
+    # 'image/webp,' from the 'Accept' header so we stop using webp through the image proxy altogether.
+    # Some relevant links:
+    # https://support.cloudflare.com/hc/en-us/articles/217343117-What-headers-can-I-vary-the-cache-on-
+    # http://stackoverflow.com/questions/37629854/impossible-to-serve-webp-images-using-cloudflare
+    # https://xenforo.com/community/threads/getting-proxy-images-to-work-well-with-cloudflare-compression-polish.105817/
+    if req.headers.accept?
+      transferred_accept_header = req.headers.accept.replace(/image\/webp,/, '')
+    else
+      transferred_accept_header = 'image/*'
+
     transferredHeaders =
       'Via'                     : user_agent
       'User-Agent'              : user_agent
-      'Accept'                  : req.headers.accept ? 'image/*'
+      'Accept'                  : transferred_accept_header
       'Accept-Encoding'         : req.headers['accept-encoding'] ? ''
       "X-Frame-Options"         : default_security_headers["X-Frame-Options"]
       "X-XSS-Protection"        : default_security_headers["X-XSS-Protection"]
@@ -239,6 +259,7 @@ server = Http.createServer (req, resp) ->
       type:     url_type
       url:      req.url
       headers:  req.headers
+      transferred_accept_header: transferred_accept_header
       dest:     dest_url
       digest:   query_digest
     })

--- a/test/proxy_test.rb
+++ b/test/proxy_test.rb
@@ -105,6 +105,22 @@ module CamoProxyTests
     end
   end
 
+  # QUANTOPIAN CHANGED - added the test below.  Try getting the avatar placeholder image
+  # via gravatar, and pass in the same 'accept' header that Chrome would pass in, including
+  # 'image/webp'.  Due to our changes in server.coffee, this should result in a png image
+  # being returned rather than a webp image.
+  def test_webp_disabled
+    response = RestClient.get(
+      request_uri(
+        'https://secure.gravatar.com/avatar/4ab6a20594384864adae340b6abfb65b?' \
+        'default=https%3A%2F%2Fs3.amazonaws.com%2Fquantopian-website-assets%2Fempty-profile.png&s=40'
+      ),
+      {accept: 'image/webp,image/*,*/*;q=0.8'}
+    )
+    assert_equal(200, response.code)
+    assert_equal('image/png', response.headers[:content_type])
+  end
+
   def test_proxy_valid_google_chart_url
     response = request('http://chart.apis.google.com/chart?chs=920x200&chxl=0:%7C2010-08-13%7C2010-09-12%7C2010-10-12%7C2010-11-11%7C1:%7C0%7C0%7C0%7C0%7C0%7C0&chm=B,EBF5FB,0,0,0&chco=008Cd6&chls=3,1,0&chg=8.3,20,1,4&chd=s:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&chxt=x,y&cht=lc')
     assert_equal(200, response.code)


### PR DESCRIPTION
This makes it so we never use webp via the image proxy, even on Chrome. This is because webp images would get stored in Cloudflare and served to Firefox, which gets rendered as a broken image (i.e. an "X") in Firefox.

After making this change I can see in the Network tab of the Chrome inspector that images that were previously being served with content type 'image/webp' in Chrome are now being served with the appropriate non-webp content type (such as 'image/png'). So I think once we deploy this fix, we'll just need to clear the Cloudflare cache to get all the existing webp images out of there.